### PR TITLE
layer.conf: redirect the deploy dir to default

### DIFF
--- a/layers/meta-balena-phytec/conf/layer.conf
+++ b/layers/meta-balena-phytec/conf/layer.conf
@@ -20,3 +20,5 @@ LAYERSERIES_COMPAT_balena-phytec = "kirkstone"
 # Balena requires that kernel-image-initramfs is deployed instead kernel-image-image.
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove:phyboard-lyra-am62xx-2 = " kernel-image-image"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append:phyboard-lyra-am62xx-2 = " kernel-image-initramfs"
+
+TI_COMMON_DEPLOY = "${DEPLOY_DIR}"


### PR DESCRIPTION
This is to solve the problem where `meta-ti` builds to `/build/deploy-ti/`  - where for our CI we need build artifacts in `/build/tmp/deploy/images/phyboard-lyra-am62xx-2/`

